### PR TITLE
chore: add structured project tasks

### DIFF
--- a/task_1.md
+++ b/task_1.md
@@ -1,0 +1,22 @@
+# Task 1 — Khởi tạo monorepo & công cụ dev
+
+## Mục tiêu
+Thiết lập skeleton monorepo theo File_Structure.md để chuẩn bị môi trường phát triển.
+
+## Các bước chính
+1. Tạo cây thư mục và các file meta: `README.md`, `LICENSE`, `.editorconfig`, `.gitignore`, `pyproject.toml`, `ruff.toml`, `pytest.ini`, `noxfile.py` hoặc `tasks.py`, `Makefile`.
+2. Thiết lập thư mục `configs/` với `agent.yaml`, `logging.yaml`, `browser_selectors.yaml`, `secrets.example.env`.
+3. Khởi tạo `scripts/` gồm `dev.ps1`, `seed_fake_data.py`, `db_migrate.py`, `export_csv.py`, `bench_foreground.py`, `health_check.ps1`.
+4. Tạo `schema/` với `app_session.schema.json` và `web_session.schema.json`.
+5. Di chuyển các tài liệu dự án hiện tại vào `docs/`.
+
+## Tài liệu tham chiếu
+- Prompt.md
+- Plan.md §3
+- File_Structure.md §1, §9
+- Work_Flow.md §0
+
+## Tiêu chí hoàn thành
+- Cấu trúc thư mục đúng như mô tả trong File_Structure.md.
+- Các file scaffold tồn tại với nội dung placeholder hợp lệ.
+- Chạy `ruff` và `pytest` không lỗi (dù chưa có test).

--- a/task_10.md
+++ b/task_10.md
@@ -1,0 +1,25 @@
+# Task 10 — FastAPI webapi
+
+## Mục tiêu
+Cung cấp API ingest và quản trị để đồng bộ dữ liệu.
+
+## Các bước chính
+1. Scaffold `webapi/main.py` tạo app FastAPI và mount routers.
+2. Tạo `webapi/core/settings.py`, `core/security.py`, `core/logging_setup.py`.
+3. Implement routers:
+   - `ingest.py` với `POST /v1/ingest/app-sessions` và `POST /v1/ingest/web-sessions`.
+   - `catalog.py` với `GET /v1/catalog/apps`, `GET /v1/catalog/domains`.
+   - `overrides.py` với `POST/GET /v1/overrides`.
+   - `health.py` với `GET /v1/healthz`.
+4. Sử dụng SQLAlchemy models và Pydantic schemas; tạo OpenAPI JSON.
+5. Viết unit test cho các endpoint chính.
+
+## Tài liệu tham chiếu
+- Prompt.md §4
+- Plan.md §4.6
+- Work_Flow.md §4, §18
+- File_Structure.md §1, §6
+
+## Tiêu chí hoàn thành
+- `uvicorn webapi.main:app --reload` khởi chạy được.
+- Tests webapi pass và OpenAPI schema sinh ra tại `/openapi.json`.

--- a/task_11.md
+++ b/task_11.md
@@ -1,0 +1,21 @@
+# Task 11 — Tray App
+
+## Mục tiêu
+Cung cấp giao diện khay hệ thống minh bạch cho người dùng với khả năng Pause/Resume.
+
+## Các bước chính
+1. Implement `tray/main.py` bằng PySide/PyQt hiển thị icon khay và menu.
+2. Tạo `tray/ipc_client.py` kết nối đến service qua IPC để điều khiển Pause/Resume và lấy trạng thái.
+3. Thêm icon `tray_recording.ico` và `tray_paused.ico` trong `tray/resources/icons/`.
+4. Menu gồm: **Pause/Resume**, "Đang ghi gì", "Chính sách & Quyền riêng tư", "Thoát".
+5. Viết unit test `tray/tests/test_tray_state.py`.
+
+## Tài liệu tham chiếu
+- Prompt.md §5
+- Plan.md §4.7
+- Work_Flow.md §3, §5, §6
+- File_Structure.md §1, §6
+
+## Tiêu chí hoàn thành
+- Tray hiển thị icon, chuyển trạng thái Pause/Resume thành công và phản ánh lên service.
+- Test tray pass.

--- a/task_12.md
+++ b/task_12.md
@@ -1,0 +1,21 @@
+# Task 12 — Dashboard webui
+
+## Mục tiêu
+Hiển thị báo cáo thời gian sử dụng ứng dụng/web và hỗ trợ export CSV.
+
+## Các bước chính
+1. Chọn phương án FastAPI template hoặc React; scaffold `webui/` tương ứng.
+2. Xây dựng trang dashboard: chọn khoảng thời gian, tổng thời gian ngày/tuần/tháng, Top app/domain, heatmap theo giờ, drill-down session.
+3. Thêm bộ lọc theo user/máy và chức năng **Export CSV**.
+4. Kết nối tới API để lấy dữ liệu; sử dụng queries trong `db/queries/reports.sql` nếu cần.
+5. Viết test giao diện cơ bản (snapshot hoặc integration).
+
+## Tài liệu tham chiếu
+- Prompt.md §6
+- Plan.md §4.8
+- Work_Flow.md §14, §18
+- File_Structure.md §6
+
+## Tiêu chí hoàn thành
+- Dashboard chạy tại `http://localhost:8000` (template) hoặc trong môi trường React.
+- Các báo cáo và export CSV hoạt động đúng dữ liệu mẫu.

--- a/task_13.md
+++ b/task_13.md
@@ -1,0 +1,21 @@
+# Task 13 — Packaging & auto-update
+
+## Mục tiêu
+Đóng gói service + tray thành bộ cài đặt và hỗ trợ cập nhật an toàn.
+
+## Các bước chính
+1. Tạo spec PyInstaller cho `service` và `tray`, sinh `agent_service.exe` và `agent_tray.exe`.
+2. Dựng installer (WiX MSI hoặc NSIS EXE) cài service auto-start và tạo shortcut Tray.
+3. Thêm scripts ký số trong `pkg/signing/` (sử dụng cert giả trong dev).
+4. Implement cơ chế auto-update: tải gói, verify chữ ký, restart an toàn, rollback nếu lỗi.
+5. Tài liệu hoá quy trình cài đặt, cập nhật và gỡ bỏ.
+
+## Tài liệu tham chiếu
+- Prompt.md §8
+- Plan.md §4.9
+- Work_Flow.md §9, §12–15
+- File_Structure.md §4
+
+## Tiêu chí hoàn thành
+- Tạo được installer chạy thử trên Windows và cài service + tray thành công.
+- Auto-update thực hiện được với bản giả lập và đảm bảo không mất dữ liệu.

--- a/task_14.md
+++ b/task_14.md
@@ -1,0 +1,20 @@
+# Task 14 — Tests & tooling
+
+## Mục tiêu
+Thiết lập bộ kiểm thử đầy đủ và công cụ hỗ trợ phát triển.
+
+## Các bước chính
+1. Viết unit tests cho các module service, webapi, tray; thêm integration tests trong `tests/`.
+2. Tạo script `scripts/seed_fake_data.py` sinh dữ liệu giả và `scripts/bench_foreground.py` benchmark collector.
+3. Thiết lập ruff lint và (tuỳ chọn) mypy/pyright type-check.
+4. Cập nhật `pytest.ini`, `noxfile.py`/`tasks.py` và `Makefile` để chạy lint+test tự động.
+
+## Tài liệu tham chiếu
+- Prompt.md §10
+- Plan.md §4.10, §11
+- Work_Flow.md §18
+- File_Structure.md §5, §9
+
+## Tiêu chí hoàn thành
+- Chạy `ruff` và `pytest` trong CI cho toàn bộ repo pass.
+- Script sinh dữ liệu giả tạo được dataset mẫu cho dashboard.

--- a/task_15.md
+++ b/task_15.md
@@ -1,0 +1,20 @@
+# Task 15 — Documentation & runbooks
+
+## Mục tiêu
+Hoàn thiện tài liệu sử dụng, chính sách và quy trình vận hành minh bạch.
+
+## Các bước chính
+1. Soạn `docs/PRIVACY_POLICY.md`, `docs/SECURITY.md`, `docs/CONTRIBUTING.md`, `docs/CHANGELOG.md`.
+2. Cập nhật `README.md` với hướng dẫn cài đặt, cấu hình, chạy service/tray/web.
+3. Viết runbooks trong `docs/` cho các tình huống thường gặp (URL không đọc được, queue đầy, ...).
+4. Liên kết tài liệu từ Tray và Dashboard.
+
+## Tài liệu tham chiếu
+- Prompt.md §7, §8, Tiêu chí nghiệm thu
+- Plan.md §7, §12, §13
+- Work_Flow.md §16–21
+- File_Structure.md §1, §10
+
+## Tiêu chí hoàn thành
+- Tài liệu đầy đủ và được lint Markdown (nếu có).
+- Người dùng mới có thể cài đặt và hiểu chính sách dữ liệu thông qua README và Privacy Policy.

--- a/task_16.md
+++ b/task_16.md
@@ -1,0 +1,25 @@
+# Task 16 — CI/CD & rollout
+
+## Mục tiêu
+Thiết lập pipeline CI/CD và triển khai pilot để hoàn tất dự án.
+
+## Các bước chính
+1. Tạo workflow GitHub Actions trong `.github/workflows/`:
+   - `ci.yml` chạy lint + test.
+   - `build.yml` build artefact service/tray/webapi/webui.
+   - `release.yml` ký số và tạo bản phát hành.
+2. Thiết lập badges trạng thái CI trong README.
+3. Thực hiện perf test mô phỏng đổi foreground 5–10 lần/giây trong 15 phút; đảm bảo CPU <2%, RAM <150MB.
+4. Triển khai pilot trên 1–2 máy nội bộ, thu thập phản hồi và logs.
+5. Đóng gói release `v1.0.0` và cập nhật CHANGELOG.
+
+## Tài liệu tham chiếu
+- Prompt.md §9, §10
+- Plan.md §§5, 8, 11, 12
+- Work_Flow.md §§17–18
+- File_Structure.md §1, §5
+
+## Tiêu chí hoàn thành
+- CI xanh cho lint/test/build.
+- Bản pilot chạy ổn định với chỉ số hiệu năng đạt mục tiêu.
+- Release `v1.0.0` được tạo và ghi nhận trong CHANGELOG.

--- a/task_2.md
+++ b/task_2.md
@@ -1,0 +1,22 @@
+# Task 2 — Thiết kế schema & DB layer
+
+## Mục tiêu
+Xây dựng mô hình dữ liệu và migration cơ sở để lưu `app_sessions` và `web_sessions`.
+
+## Các bước chính
+1. Tạo package `db/models/` với các model: `base.py`, `device.py`, `user.py`, `app.py`, `app_session.py`, `web_domain.py`, `web_session.py`, `override.py`, `audit_log.py`.
+2. Khởi tạo Alembic trong `db/migrations/` và tạo migration đầu tiên.
+3. Soạn `db/queries/reports.sql` và `db/queries/maintenance.sql`.
+4. Tạo `db/local_dev.sqlite` (bỏ qua trong git).
+5. Cập nhật `schema/*.schema.json` tương ứng.
+
+## Tài liệu tham chiếu
+- Prompt.md §3
+- Plan.md §4.5, Phụ lục 13.1
+- Diagram.md (ERD)
+- File_Structure.md §1, §6
+- Work_Flow.md §5–6
+
+## Tiêu chí hoàn thành
+- Chạy `python scripts/db_migrate.py upgrade head` tạo schema thành công.
+- Các model được import bởi service và webapi.

--- a/task_3.md
+++ b/task_3.md
@@ -1,0 +1,21 @@
+# Task 3 — Thiết lập skeleton Service & IPC
+
+## Mục tiêu
+Tạo Windows Service cơ bản với cấu hình, logging và kênh IPC cho Tray.
+
+## Các bước chính
+1. Viết `service/agent_service.py` kế thừa `win32serviceutil.ServiceFramework` (start/stop, control handler, chế độ `--debug`).
+2. Xây dựng `service/agent_config.py` đọc `configs/agent.yaml` và biến môi trường.
+3. Thêm `service/logging_setup.py` để nạp `configs/logging.yaml`.
+4. Tạo `service/ipc.py` làm kênh IPC (named pipe hoặc socket) giữa Service và Tray.
+5. Thêm `service/healthcheck.py` cung cấp trạng thái `/v1/healthz` nội bộ.
+6. Tạo stub cho `idle_detector.py`, `session_aggregator.py`, `batcher.py`, `uploader.py` (chưa xử lý logic).
+
+## Tài liệu tham chiếu
+- Prompt.md §1, §4, §5
+- Plan.md §3, §4.1, §4.2
+- Work_Flow.md §4
+- File_Structure.md §1, §7
+
+## Tiêu chí hoàn thành
+- Chạy `python service/agent_service.py --debug` khởi động không lỗi và ghi log "Service started".

--- a/task_4.md
+++ b/task_4.md
@@ -1,0 +1,20 @@
+# Task 4 — Idle detector & Session aggregator
+
+## Mục tiêu
+Ghi nhận trạng thái idle và gộp phiên ứng dụng/web chính xác.
+
+## Các bước chính
+1. Implement `service/idle_detector.py` sử dụng `GetLastInputInfo`, đọc ngưỡng từ config.
+2. Implement `service/session_aggregator.py` với quy tắc merge (gap<5s), xử lý idle và chống chồng lấn.
+3. Viết unit test: `service/tests/test_idle_detector.py`, `service/tests/test_session_aggregator.py`.
+4. Tích hợp các module vào `agent_service` và xuất metric đơn giản.
+
+## Tài liệu tham chiếu
+- Prompt.md §1
+- Plan.md §4.1, §4.2, §9
+- Work_Flow.md §§5–6, Phụ lục A.1
+- File_Structure.md §7
+
+## Tiêu chí hoàn thành
+- `pytest service/tests/test_idle_detector.py service/tests/test_session_aggregator.py` pass.
+- Khi idle vượt ngưỡng, phiên đang mở được đóng và không cộng thời gian.

--- a/task_5.md
+++ b/task_5.md
@@ -1,0 +1,21 @@
+# Task 5 — Queue SQLite & uploader
+
+## Mục tiêu
+Lưu trữ tạm thời các sự kiện và đồng bộ lên API an toàn.
+
+## Các bước chính
+1. Implement `service/storage/queue_sqlite.py` với schema queue và cơ chế dedupe theo hash.
+2. Implement `service/storage/retention.py` để xoay DB và áp dụng TTL.
+3. Xây dựng `service/batcher.py` gom sự kiện theo `batch.size` và `batch.interval_ms`.
+4. Implement `service/uploader.py` sử dụng JWT + TLS, retry/backoff, queue offline khi mất mạng.
+5. Viết `service/tests/test_queue_sqlite.py` và test uploader bằng API mock.
+
+## Tài liệu tham chiếu
+- Prompt.md §3, §4, §9
+- Plan.md §4.5, §9
+- Work_Flow.md §§4–8, §18
+- File_Structure.md §7
+
+## Tiêu chí hoàn thành
+- Unit test queue SQLite pass.
+- Service có thể ghi sự kiện vào queue và uploader gửi thành công tới API mock.

--- a/task_6.md
+++ b/task_6.md
@@ -1,0 +1,20 @@
+# Task 6 — Collector `proc_focus`
+
+## Mục tiêu
+Theo dõi process start/stop và foreground window để tạo `app_sessions`.
+
+## Các bước chính
+1. Implement `service/collectors/proc_focus.py` sử dụng `SetWinEventHook(EVENT_SYSTEM_FOREGROUND)` và `psutil`/WMI.
+2. Ghi nhận `name`, `exe_path`, `pid`, `publisher` (nếu có), `sha256` file exe.
+3. Cập nhật `session_aggregator` khi foreground đổi; lấy mẫu `window_title` định kỳ.
+4. Tích hợp kiểm tra idle trước khi mở phiên mới.
+5. Viết test mô phỏng sự kiện foreground.
+
+## Tài liệu tham chiếu
+- Prompt.md §1
+- Plan.md §4.1
+- Work_Flow.md §5, Phụ lục A.1
+- File_Structure.md §6, §7
+
+## Tiêu chí hoàn thành
+- Chạy service, chuyển đổi giữa vài ứng dụng tạo `app_sessions` chính xác, idle không cộng thời gian.

--- a/task_7.md
+++ b/task_7.md
@@ -1,0 +1,21 @@
+# Task 7 — Collector `uia_web`
+
+## Mục tiêu
+Ghi URL và title của tab trình duyệt foreground mà không dùng extension.
+
+## Các bước chính
+1. Implement `service/collectors/uia_web/uia_reader.py` dùng UIAutomation tìm Address Bar (`Edit`/`ComboBox`) và đọc URL + tab title.
+2. Xây dựng `service/collectors/uia_web/selectors.py` và cập nhật `configs/browser_selectors.yaml`.
+3. Poll 1–2s hoặc theo sự kiện foreground để gộp `web_session` theo `(browser, URL)`.
+4. Fallback: nếu không đọc được URL, lưu domain từ title hoặc chờ ETW.
+5. Viết `service/tests/test_uia_reader.py`.
+
+## Tài liệu tham chiếu
+- Prompt.md §2
+- Plan.md §4.2
+- Work_Flow.md §6, Phụ lục A.2
+- File_Structure.md §6, §7
+
+## Tiêu chí hoàn thành
+- Tỷ lệ lấy URL thành công ≥95% trên Chrome/Edge/Firefox trong thử nghiệm thủ công.
+- Unit test `test_uia_reader.py` pass.

--- a/task_8.md
+++ b/task_8.md
@@ -1,0 +1,20 @@
+# Task 8 — Collector `history_backfill`
+
+## Mục tiêu
+Backfill URL và thời điểm truy cập từ lịch sử trình duyệt để lấp các khoảng UIA bỏ lỡ.
+
+## Các bước chính
+1. Implement `service/collectors/history_backfill.py` sao chép file History SQLite sang thư mục tạm và đọc bảng `urls/visits`.
+2. Map các visit với khoảng thời gian foreground để ước lượng `active_seconds` còn thiếu.
+3. Cho phép cấu hình chu kỳ (5–10 phút) trong `agent.yaml`.
+4. Viết test giả lập file History bị khóa.
+
+## Tài liệu tham chiếu
+- Prompt.md §2 (History Backfill)
+- Plan.md §4.3
+- Work_Flow.md §7
+- File_Structure.md §6, §7
+
+## Tiêu chí hoàn thành
+- Các URL bỏ lỡ bởi UIA được backfill vào DB cục bộ.
+- Unit test history backfill pass.

--- a/task_9.md
+++ b/task_9.md
@@ -1,0 +1,21 @@
+# Task 9 — Collector `etw_domain`
+
+## Mục tiêu
+Nghe ETW Network để map process ⇄ domain ở mức SNI/host.
+
+## Các bước chính
+1. Implement `service/collectors/etw_domain.py` (có thể dùng `krabsetw` hoặc module C# phụ) lắng các provider `Microsoft-Windows-TCPIP`, `WinInet`, `MsQuic`.
+2. Parse sự kiện để lấy domain và PID, lưu vào queue ở mức domain (không path).
+3. Kết hợp với `web_session` khi UIA/History không có URL.
+4. Tùy chọn bật/tắt qua config `features.etw_domain`.
+5. Viết test mô phỏng sự kiện ETW.
+
+## Tài liệu tham chiếu
+- Prompt.md §2 (ETW Network)
+- Plan.md §4.4
+- Work_Flow.md §8
+- File_Structure.md §6, §7
+
+## Tiêu chí hoàn thành
+- Collector ghi nhận được domain cho process khi không đọc được URL.
+- Test ETW giả lập pass.


### PR DESCRIPTION
## Summary
- outline 16 tasks covering scaffolding, collectors, API, packaging, docs, and rollout

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab2faa190883289b5e50be5b16f130